### PR TITLE
added proxy support

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,7 +4,10 @@ CTBotInlineKeyboard	KEYWORD1
 setIP	KEYWORD2
 wifiConnect	KEYWORD2
 setTelegramToken	KEYWORD2
+setTelegramIP	KEYWORD2
+setTelegramPort	KEYWORD2
 useDNS	KEYWORD2
+useProxy	KEYWORD2
 enableUTF8Encoding	KEYWORD2
 setMaxConnectionRetries	KEYWORD2
 setStatusPin	KEYWORD2

--- a/src/CTBot.cpp
+++ b/src/CTBot.cpp
@@ -4,8 +4,6 @@
 #include "CTBot.h"
 
 #define TELEGRAM_URL  "api.telegram.org"
-#define TELEGRAM_IP   "149.154.167.198"
-#define TELEGRAM_PORT 443
 // get fingerprints from https://www.grc.com/fingerprints.htm
 const uint8_t fingerprint[20] = { 0xBB, 0xDC, 0x45, 0x2A, 0x07, 0xE3, 0x4A, 0x71, 0x33, 0x40, 0x32, 0xDA, 0xBE, 0x81, 0xF7, 0x72, 0x6F, 0x4A, 0x2B, 0x6B };
 
@@ -86,6 +84,8 @@ CTBot::CTBot() {
 	m_useDNS              = false; // use static IP for Telegram Server
 	m_UTF8Encoding        = false; // no UTF8 encoded string conversion
 	setFingerprint(fingerprint);   // set the default fingerprint
+	TELEGRAM_IP = "149.154.167.198";
+	TELEGRAM_PORT = 443;
 }
 
 CTBot::~CTBot() {
@@ -94,7 +94,7 @@ CTBot::~CTBot() {
 String CTBot::sendCommand(String command, String parameters)
 {
 #if CTBOT_USE_FINGERPRINT == 0
-	WiFiClientSecure telegramServer;
+	WiFiClient telegramServer;
 #else
 	BearSSL::WiFiClientSecure telegramServer;
 	telegramServer.setFingerprint(m_fingerprint);
@@ -136,10 +136,13 @@ String CTBot::sendCommand(String command, String parameters)
 		digitalWrite(m_statusPin, !digitalRead(m_statusPin));     // set pin to the opposite state
 
 	// must filter command + parameters from escape sequences and spaces
-	String URL = "GET /bot" + m_token + (String)"/" + toURL(command + parameters);
-
+	String URL = "GET https://api.telegram.org/bot" + m_token + (String)"/" + toURL(command + parameters);
 	// send the HTTP request
-	telegramServer.println(URL);
+	String request = URL + String(" HTTP/1.1\r\n") +
+					"Host: " + TELEGRAM_URL + String("\r\n") +
+					String("Accept-Encoding: identity\r\n") +
+					String("\r\n");
+	telegramServer.print(request);
 
 	if (m_statusPin != CTBOT_DISABLE_STATUS_PIN)
 		digitalWrite(m_statusPin, !digitalRead(m_statusPin));     // set pin to the opposite state
@@ -149,6 +152,11 @@ String CTBot::sendCommand(String command, String parameters)
 	bool skipCounter = false; // for filtering curly bracket inside a text message
 	curlyCounter = -1;
 	response = "";
+	
+	while (telegramServer.connected()) {
+	  if(telegramServer.readStringUntil('\n')=="\r")
+		break;
+	}
 
 	while (telegramServer.connected()) {
 		while (telegramServer.available()) {
@@ -482,6 +490,19 @@ void CTBot::setFingerprint(const uint8_t * newFingerprint)
 {
 	for (int i = 0; i < 20; i++)
 		m_fingerprint[i] = newFingerprint[i];
+}
+
+void CTBot::setTelegramIP(String IP){
+	TELEGRAM_IP = IP;
+}
+
+void CTBot::setTelegramPort(int port){
+	TELEGRAM_PORT = port;
+}
+
+void CTBot::useProxy(String IP, int port){
+	setTelegramIP(IP);
+	setTelegramPort(port);
 }
 
 bool CTBot::setIP(String ip, String gateway, String subnetMask, String dns1, String dns2){

--- a/src/CTBot.h
+++ b/src/CTBot.h
@@ -125,6 +125,19 @@ public:
 	// params:
 	//    newFingerprint: the array of 20 bytes that contains the new fingerprint
 	void setFingerprint(const uint8_t *newFingerprint);
+	
+	void setTelegramIP(String IP);
+	
+	void setTelegramPort(int port);
+	
+	// sets a proxy which should be used in case connection to api.telegram.org fails
+	// no SSL so no encryption of the requests!!!
+	// CTBOT_USE_FINGERPRINT must be 0
+	//params:
+	//		IP: IP of a HTTP proxy-server. If the response time of the server is too long
+	//			the requests will timeout
+	//      port: port of the proxy-server
+	void useProxy(String IP, int port);
 
 private:
 	uint8_t   m_wifiConnectionTries;
@@ -135,6 +148,8 @@ private:
 	bool      m_UTF8Encoding;
 	bool      m_needInsecureFlag;
 	uint8_t   m_fingerprint[20];
+	String 	  TELEGRAM_IP;
+	int       TELEGRAM_PORT;
 	// send data to the serial port. It work only if the CTBOT_DEBUG_MODE is enabled.
 	// params
 	//    message: the message to send


### PR DESCRIPTION
This commit adds proxy support to the CTBot.
For now only HTTP proxies are supported, so set CTBOT_USE_FINGERPRINT=0 .
The requests fail, if the response time of the proxy takes to long.
Test the proxy beforehand with python i.e. :

`import http     
from http import client

h1 = http.client.HTTPConnection('34.244.2.233:8123')
# h1 = http.client.HTTPSConnection('api.telegram.org')
h1.request('GET','https://api.telegram.org/bot%ID:token%/getMe')
r1 = h1.getresponse()
print(r1.status, r1.reason)
print(r1.read())`

The response should be:

`200 OK
b'{"ok":true,"result":{"id":123456789,"is_bot":true,"first_name":"some_name","username":"some_nameBot"}}'`